### PR TITLE
Fix IsValidAddress() to support leading digit

### DIFF
--- a/stringutil/regex.go
+++ b/stringutil/regex.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// HostnameRegex is the regex for valid hostnames.
-	HostnameRegex = regexp.MustCompile(`^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+	HostnameRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 	// IPV4Regex is the regex for valid IPv4 addresses.
 	IPV4Regex = regexp.MustCompile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
 )

--- a/stringutil/regex_test.go
+++ b/stringutil/regex_test.go
@@ -30,6 +30,22 @@ func TestIsValidAddressErr(t *testing.T) {
 			value:    "service_1.dc1.ru:6060",
 			positive: false,
 		},
+		{
+			value:    "123service:6060",
+			positive: true,
+		},
+		{
+			value:    "123service.dc1.ru:6060",
+			positive: true,
+		},
+		{
+			value:    "1:6060",
+			positive: true,
+		},
+		{
+			value:    "1.dc1.ru:6060",
+			positive: true,
+		},
 	} {
 		tc := tc
 		t.Run(tc.value, func(t *testing.T) {


### PR DESCRIPTION
This pull request updates the regex for matching hostnames so that they can accept ones that start with a digit. This wasn't previously allowed according to [RFC 952 (1985)](https://www.rfc-editor.org/rfc/rfc952) but was updated with [RFC 1123 (1989)](https://www.rfc-editor.org/rfc/rfc1123).

Here's the text of the relevant section of the RFC 1123:

```
2.  GENERAL ISSUES

   This section contains general requirements that may be applicable to
   all application-layer protocols.

   2.1  Host Names and Numbers

      The syntax of a legal Internet host name was specified in RFC-952
      [DNS:4].  One aspect of host name syntax is hereby changed: the
      restriction on the first character is relaxed to allow either a
      letter or a digit.  Host software MUST support this more liberal
      syntax.
```

I noticed this issue when deploying Dragonboat to our servers which start with a hexadecimal hostname. I can add a follow up PR for Dragonboat once this is merged.

Thanks!