### PR TITLE
improve address validator

### DIFF
--- a/stringutil/regex.go
+++ b/stringutil/regex.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// HostnameRegex is the regex for valid hostnames.
-	HostnameRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+	HostnameRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z])$`)
 	// IPV4Regex is the regex for valid IPv4 addresses.
 	IPV4Regex = regexp.MustCompile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
 )

--- a/stringutil/regex_test.go
+++ b/stringutil/regex_test.go
@@ -46,6 +46,22 @@ func TestIsValidAddressErr(t *testing.T) {
 			value:    "1.dc1.ru:6060",
 			positive: true,
 		},
+		{
+			value:    "192.168.0.255:6060",
+			positive: true,
+		},
+		{
+			value:    "192.168.0.300:6060",
+			positive: false,
+		},
+		{
+			value:    "1.dc1.499:6060",
+			positive: false,
+		},
+		{
+			value:    "1.dc1.255:6060",
+			positive: false,
+		},
 	} {
 		tc := tc
 		t.Run(tc.value, func(t *testing.T) {


### PR DESCRIPTION
Now there is limitation that `192.168.0.300` is valid hostname. 

more details https://github.com/lni/dragonboat/issues/340

